### PR TITLE
Add spinbot feature (player body spin for trolling)

### DIFF
--- a/PhasmoCheatV Recode.vcxproj
+++ b/PhasmoCheatV Recode.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="main\features\feats\curseditemscontroll\curseditemscontroll.cpp" />
     <ClCompile Include="main\features\feats\custname\customname.cpp" />
     <ClCompile Include="main\features\feats\custspeed\customspeed.cpp" />
+    <ClCompile Include="main\features\feats\spinbot\spinbot.cpp" />
     <ClCompile Include="main\features\feats\diffmod\difficultymodifier.cpp" />
     <ClCompile Include="main\features\feats\doormod\doormodifier.cpp" />
     <ClCompile Include="main\features\feats\edvesp\edvesp.cpp" />
@@ -350,6 +351,7 @@
     <ClInclude Include="main\features\feats\curseditemscontroll\curseditemscontroll.h" />
     <ClInclude Include="main\features\feats\custname\customname.h" />
     <ClInclude Include="main\features\feats\custspeed\customspeed.h" />
+    <ClInclude Include="main\features\feats\spinbot\spinbot.h" />
     <ClInclude Include="main\features\feats\diffmod\difficultymodifier.h" />
     <ClInclude Include="main\features\feats\doormod\doormodifier.h" />
     <ClInclude Include="main\features\feats\edvesp\edvesp.h" />

--- a/PhasmoCheatV Recode.vcxproj.filters
+++ b/PhasmoCheatV Recode.vcxproj.filters
@@ -228,6 +228,9 @@
     <ClCompile Include="main\features\feats\custspeed\customspeed.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
+    <ClCompile Include="main\features\feats\spinbot\spinbot.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
     <ClCompile Include="main\features\feats\teleport\teleport.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
@@ -804,6 +807,9 @@
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\custspeed\customspeed.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\spinbot\spinbot.h">
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\teleport\teleport.h">

--- a/main/config/Translations.h
+++ b/main/config/Translations.h
@@ -119,6 +119,11 @@ inline void RegisterAllTranslations()
     ADD_STR("CustomSpeedEnabled", "Enable custom speed##custSpeed", u8"Включить пользовательскую скорость##custSpeed", u8"启用自定义速度##custSpeed");
     ADD_STR("CustomSpeedSlider", "Custom speed##custSpeed", u8"Пользовательская скорость##custSpeed", u8"请设置速度##custSpeed");
 
+    // Spinbot
+    ADD_STR("Spinbot_Header", "Spinbot", u8"Спинбот", u8"旋转陀螺");
+    ADD_STR("SpinbotEnabled", "Enable spinbot##spinbot", u8"Включить спинбот##spinbot", u8"启用旋转陀螺##spinbot");
+    ADD_STR("SpinbotSpeed", "Spin speed##spinbot", u8"Скорость вращения##spinbot", u8"旋转速度##spinbot");
+
     // Difficulty 
     ADD_STR("RequiredLevel", "RequiredLevel", u8"Требуемый уровень", u8"所需等级");
     ADD_STR("SanityPillRestoration", "SanityPillRestoration", u8"Восстановление санпайлов", u8"醒脑丸恢复理智量");

--- a/main/features/feats/spinbot/spinbot.cpp
+++ b/main/features/feats/spinbot/spinbot.cpp
@@ -1,0 +1,53 @@
+#include "spinbot.h"
+#include <cmath>
+
+using namespace PhasmoCheatV::Features::Misc;
+
+Spinbot::Spinbot() : FeatureCore(LANG("Spinbot_Header"), TYPE_MISC)
+{
+	DECLARE_CONFIG(GetConfigManager(), "Speed", float, 360.0f);
+}
+
+void Spinbot::OnMenuRender()
+{
+	bool enabled = IsActive();
+	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
+	if (BCheckBox(LANG("SpinbotEnabled"), &enabled, "b_SpinbotEnabled"))
+	{
+		SET_CONFIG_VALUE(GetConfigManager(), "Enabled", bool, enabled);
+		if (enabled) OnActivate();
+		else OnDeactivate();
+	}
+	if (ImGui::SliderFloat(LANG("SpinbotSpeed"), &speed, 0.0f, 2000.0f, "%.0f deg/s"))
+		SET_CONFIG_VALUE(GetConfigManager(), "Speed", float, speed);
+}
+
+void Spinbot::SpinbotMain(SDK::FirstPersonController* firstPersonController)
+{
+	if (!IsActive()) return;
+
+	auto* player = Utils::GetLocalPlayer();
+	if (!player || !player->Fields.LocalPlayer) return;
+
+	auto* camera = player->Fields.LocalPlayer->Fields.Camera;
+	if (!camera) return;
+
+	auto* bodyTransform = SDK::Component_Get_Transform(
+		reinterpret_cast<SDK::Component*>(firstPersonController), nullptr);
+	auto* cameraTransform = SDK::Component_Get_Transform(
+		reinterpret_cast<SDK::Component*>(camera), nullptr);
+	if (!bodyTransform || !cameraTransform) return;
+
+	SDK::Quaternion savedCameraRot = SDK::Transform_Get_Rotation(cameraTransform, nullptr);
+
+	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
+	float dt = SDK::Time_Get_DeltaTime(nullptr);
+	m_spinAngle += speed * dt * 0.0174533f; // deg to rad
+	if (m_spinAngle > 6.2831853f) m_spinAngle -= 6.2831853f;
+
+	float halfAngle = m_spinAngle * 0.5f;
+	SDK::Quaternion yRot = { 0.0f, sinf(halfAngle), 0.0f, cosf(halfAngle) };
+
+	SDK::Transform_Set_Rotation(bodyTransform, yRot, nullptr);
+	SDK::Transform_Set_Rotation(cameraTransform, savedCameraRot, nullptr);
+}

--- a/main/features/feats/spinbot/spinbot.h
+++ b/main/features/feats/spinbot/spinbot.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../Includes.h"
+
+namespace PhasmoCheatV::Features::Misc
+{
+	class Spinbot final : public FeatureCore
+	{
+	public:
+		explicit Spinbot();
+		~Spinbot() override = default;
+
+		void OnActivate() override {}
+		void OnDeactivate() override {}
+		void OnRender() override {}
+		void OnMenuRender() override;
+
+		void SpinbotMain(SDK::FirstPersonController* firstPersonController);
+	private:
+		float m_spinAngle = 0.0f;
+	};
+}

--- a/main/features/feature.cpp
+++ b/main/features/feature.cpp
@@ -100,6 +100,7 @@ FeatureHandler::FeatureHandler() : CurrentType(TYPE_NONE)
     ADD_FEATURE(this, Teleport);
 
     // Misc
+    ADD_FEATURE(this, Spinbot);
     ADD_FEATURE(this, AntiKick);
     ADD_FEATURE(this, ExitVanOne);
     ADD_FEATURE(this, VanButtonModifier);

--- a/main/features/features_includes.h
+++ b/main/features/features_includes.h
@@ -24,6 +24,7 @@
 #include "feats/noclip/noclip.h"
 #include "feats/infstamina/infinitystamina.h"
 #include "feats/custspeed/customspeed.h"
+#include "feats/spinbot/spinbot.h"
 #include "feats/teleport/teleport.h"
 #include "feats/exitvanone/exitvanone.h"
 #include "feats/antikick/antikick.h"

--- a/main/hooks/FirstPersonController_Update.cpp
+++ b/main/hooks/FirstPersonController_Update.cpp
@@ -20,6 +20,7 @@ void Hooks::hkFirstPersonController_Update(SDK::FirstPersonController* firstPers
 	CALL_METHOD_IF_ACTIVE(Players, CrosshairModifier, CrosshairModifierMain);
 	CALL_METHOD(Cursed, CursedItemsControll, CursedItemsControllMain);
 	CALL_METHOD(Misc, AudioModifier, AudioModifierHandler);
+	CALL_METHOD_IF_ACTIVE_ARGS(Misc, Spinbot, SpinbotMain, firstPersonController);
 
 	CALL_METHOD(Visuals, Fullbright, FullbrightMain);
 }


### PR DESCRIPTION
## Summary

Add a CS:GO-style spinbot: other players see you spinning in place while your local view stays normal.

## What it does

- Toggle to enable, slider 0 ~ 2000 deg/s (default 360)
- Spins the player body around the Y axis each frame
- Preserves the camera world rotation so the local view is unaffected
- Registered under Misc category

## How it works

The camera is a child of the body GameObject — rotating the body normally spins the camera too. The fix:

1. Save camera world rotation: `Transform_Get_Rotation(cameraTransform)`
2. Set body Y-rotation via manually computed quaternion `{0, sin(θ/2), 0, cos(θ/2)}`
3. Restore camera world rotation — Unity recomputes the correct local rotation to compensate

All operations run after the original `FirstPersonController.Update` call, overriding the MouseLook output.

https://github.com/user-attachments/assets/6fac4d36-8b76-4b3b-9e37-d276f4133faa


