### PR TITLE
Add GhostSpin & GhostHandstand features

### DIFF
--- a/PhasmoCheatV Recode.vcxproj
+++ b/PhasmoCheatV Recode.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="main\features\feats\custname\customname.cpp" />
     <ClCompile Include="main\features\feats\custspeed\customspeed.cpp" />
     <ClCompile Include="main\features\feats\ghostspin\ghostspin.cpp" />
+    <ClCompile Include="main\features\feats\ghosthandstand\ghosthandstand.cpp" />
     <ClCompile Include="main\features\feats\diffmod\difficultymodifier.cpp" />
     <ClCompile Include="main\features\feats\doormod\doormodifier.cpp" />
     <ClCompile Include="main\features\feats\edvesp\edvesp.cpp" />
@@ -352,6 +353,7 @@
     <ClInclude Include="main\features\feats\custname\customname.h" />
     <ClInclude Include="main\features\feats\custspeed\customspeed.h" />
     <ClInclude Include="main\features\feats\ghostspin\ghostspin.h" />
+    <ClInclude Include="main\features\feats\ghosthandstand\ghosthandstand.h" />
     <ClInclude Include="main\features\feats\diffmod\difficultymodifier.h" />
     <ClInclude Include="main\features\feats\doormod\doormodifier.h" />
     <ClInclude Include="main\features\feats\edvesp\edvesp.h" />

--- a/PhasmoCheatV Recode.vcxproj
+++ b/PhasmoCheatV Recode.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="main\features\feats\curseditemscontroll\curseditemscontroll.cpp" />
     <ClCompile Include="main\features\feats\custname\customname.cpp" />
     <ClCompile Include="main\features\feats\custspeed\customspeed.cpp" />
+    <ClCompile Include="main\features\feats\ghostspin\ghostspin.cpp" />
     <ClCompile Include="main\features\feats\diffmod\difficultymodifier.cpp" />
     <ClCompile Include="main\features\feats\doormod\doormodifier.cpp" />
     <ClCompile Include="main\features\feats\edvesp\edvesp.cpp" />
@@ -350,6 +351,7 @@
     <ClInclude Include="main\features\feats\curseditemscontroll\curseditemscontroll.h" />
     <ClInclude Include="main\features\feats\custname\customname.h" />
     <ClInclude Include="main\features\feats\custspeed\customspeed.h" />
+    <ClInclude Include="main\features\feats\ghostspin\ghostspin.h" />
     <ClInclude Include="main\features\feats\diffmod\difficultymodifier.h" />
     <ClInclude Include="main\features\feats\doormod\doormodifier.h" />
     <ClInclude Include="main\features\feats\edvesp\edvesp.h" />

--- a/PhasmoCheatV Recode.vcxproj.filters
+++ b/PhasmoCheatV Recode.vcxproj.filters
@@ -228,6 +228,9 @@
     <ClCompile Include="main\features\feats\custspeed\customspeed.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
+    <ClCompile Include="main\features\feats\ghostspin\ghostspin.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
     <ClCompile Include="main\features\feats\teleport\teleport.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
@@ -804,6 +807,9 @@
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\custspeed\customspeed.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostspin\ghostspin.h">
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\teleport\teleport.h">

--- a/PhasmoCheatV Recode.vcxproj.filters
+++ b/PhasmoCheatV Recode.vcxproj.filters
@@ -231,6 +231,9 @@
     <ClCompile Include="main\features\feats\ghostspin\ghostspin.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
+    <ClCompile Include="main\features\feats\ghosthandstand\ghosthandstand.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
     <ClCompile Include="main\features\feats\teleport\teleport.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
@@ -810,6 +813,9 @@
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\ghostspin\ghostspin.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghosthandstand\ghosthandstand.h">
       <Filter>Файлы заголовков</Filter>
     </ClInclude>
     <ClInclude Include="main\features\feats\teleport\teleport.h">

--- a/main/config/Translations.h
+++ b/main/config/Translations.h
@@ -119,6 +119,11 @@ inline void RegisterAllTranslations()
     ADD_STR("CustomSpeedEnabled", "Enable custom speed##custSpeed", u8"Включить пользовательскую скорость##custSpeed", u8"启用自定义速度##custSpeed");
     ADD_STR("CustomSpeedSlider", "Custom speed##custSpeed", u8"Пользовательская скорость##custSpeed", u8"请设置速度##custSpeed");
 
+    // Ghost spin
+    ADD_STR("GhostSpin_Header", "Ghost Spin", u8"Вращение призрака", u8"旋转鬼魂");
+    ADD_STR("GhostSpinEnabled", "Enable ghost spin##ghostSpin", u8"Включить вращение призрака##ghostSpin", u8"启用旋转鬼魂##ghostSpin");
+    ADD_STR("GhostSpinSpeed", "Spin speed##ghostSpin", u8"Скорость вращения##ghostSpin", u8"旋转速度##ghostSpin");
+
     // Difficulty 
     ADD_STR("RequiredLevel", "RequiredLevel", u8"Требуемый уровень", u8"所需等级");
     ADD_STR("SanityPillRestoration", "SanityPillRestoration", u8"Восстановление санпайлов", u8"醒脑丸恢复理智量");

--- a/main/config/Translations.h
+++ b/main/config/Translations.h
@@ -124,6 +124,10 @@ inline void RegisterAllTranslations()
     ADD_STR("GhostSpinEnabled", "Enable ghost spin##ghostSpin", u8"Включить вращение призрака##ghostSpin", u8"启用旋转鬼魂##ghostSpin");
     ADD_STR("GhostSpinSpeed", "Spin speed##ghostSpin", u8"Скорость вращения##ghostSpin", u8"旋转速度##ghostSpin");
 
+    // Ghost handstand
+    ADD_STR("GhostHandstand_Header", "Ghost Handstand", u8"Призрак вверх ногами", u8"鬼魂倒立");
+    ADD_STR("GhostHandstandEnabled", "Enable ghost handstand##ghostHandstand", u8"Включить призрак вверх ногами##ghostHandstand", u8"启用鬼魂倒立##ghostHandstand");
+
     // Difficulty 
     ADD_STR("RequiredLevel", "RequiredLevel", u8"Требуемый уровень", u8"所需等级");
     ADD_STR("SanityPillRestoration", "SanityPillRestoration", u8"Восстановление санпайлов", u8"醒脑丸恢复理智量");

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -23,14 +23,10 @@ void GhostHandstand::OnMenuRender()
 
 void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 {
-	if (!ghostAI || !ghostAI->Fields.currentModel) return;
+	if (!ghostAI || !ghostAI->Fields.raycastPoint) return;
 
-	auto* animator = ghostAI->Fields.currentModel->Fields.anim;
-	if (!animator) return;
-
-	auto* modelTransform = SDK::Component_Get_Transform(
-		reinterpret_cast<SDK::Component*>(animator), nullptr);
-	if (!modelTransform) return;
+	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
+	if (!bodyTransform) return;
 
 	if (IsActive())
 	{
@@ -43,22 +39,22 @@ void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 		}
 		if (ghostHeight <= 0.0f) ghostHeight = 1.8f;
 
-		SDK::Transform_Set_Rotation(modelTransform, handstandQuat, nullptr);
+		SDK::Transform_Set_Rotation(bodyTransform, handstandQuat, nullptr);
 
-		auto pos = SDK::Transform_Get_Position(modelTransform, nullptr);
+		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
 		pos.Y += ghostHeight;
-		SDK::Transform_Set_Position(modelTransform, pos, nullptr);
+		SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
 
 		m_applied = true;
 		m_offsetY = ghostHeight;
 	}
 	else if (m_applied)
 	{
-		SDK::Transform_Set_Rotation(modelTransform, identityQuat, nullptr);
+		SDK::Transform_Set_Rotation(bodyTransform, identityQuat, nullptr);
 
-		auto pos = SDK::Transform_Get_Position(modelTransform, nullptr);
+		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
 		pos.Y -= m_offsetY;
-		SDK::Transform_Set_Position(modelTransform, pos, nullptr);
+		SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
 
 		m_applied = false;
 	}

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -2,9 +2,8 @@
 
 using namespace PhasmoCheatV::Features::Misc;
 
-// 180 degrees around X axis: (sin(pi/2), 0, 0, cos(pi/2)) = (1, 0, 0, 0)
-static const SDK::Quaternion handstandQuat = { 1.0f, 0.0f, 0.0f, 0.0f };
-static const SDK::Quaternion identityQuat   = { 0.0f, 0.0f, 0.0f, 1.0f };
+static const SDK::Vector3 flippedScale  = { 1.0f, -1.0f, 1.0f };
+static const SDK::Vector3 normalScale   = { 1.0f,  1.0f, 1.0f };
 
 GhostHandstand::GhostHandstand() : FeatureCore(LANG("GhostHandstand_Header"), TYPE_MISC)
 {
@@ -39,7 +38,7 @@ void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 		}
 		if (ghostHeight <= 0.0f) ghostHeight = 1.8f;
 
-		SDK::Transform_Set_Rotation(bodyTransform, handstandQuat, nullptr);
+		SDK::Transform_Set_localScale(bodyTransform, flippedScale, nullptr);
 
 		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
 		pos.Y += ghostHeight;
@@ -50,7 +49,7 @@ void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 	}
 	else if (m_applied)
 	{
-		SDK::Transform_Set_Rotation(bodyTransform, identityQuat, nullptr);
+		SDK::Transform_Set_localScale(bodyTransform, normalScale, nullptr);
 
 		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
 		pos.Y -= m_offsetY;

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -27,34 +27,34 @@ void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
 	if (!bodyTransform) return;
 
-	if (IsActive())
+	if (!IsActive())
 	{
-		float ghostHeight = 0.0f;
-		if (ghostAI->Fields.raycastPoint && ghostAI->Fields.feetRaycastPoint)
+		if (m_basePosSet)
+		{
+			SDK::Transform_Set_localScale(bodyTransform, normalScale, nullptr);
+			SDK::Transform_Set_Position(bodyTransform, m_baseBodyPos, nullptr);
+			m_basePosSet = false;
+		}
+		return;
+	}
+
+	// Capture base position and model height on first active frame
+	if (!m_basePosSet)
+	{
+		m_baseBodyPos = SDK::Transform_Get_Position(bodyTransform, nullptr);
+		if (ghostAI->Fields.feetRaycastPoint)
 		{
 			auto top = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr);
 			auto bottom = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr);
-			ghostHeight = top.Y - bottom.Y;
+			m_modelHeight = top.Y - bottom.Y;
 		}
-		if (ghostHeight <= 0.0f) ghostHeight = 1.8f;
-
-		SDK::Transform_Set_localScale(bodyTransform, flippedScale, nullptr);
-
-		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
-		pos.Y += ghostHeight;
-		SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
-
-		m_applied = true;
-		m_offsetY = ghostHeight;
+		if (m_modelHeight <= 0.0f) m_modelHeight = 1.8f;
+		m_basePosSet = true;
 	}
-	else if (m_applied)
-	{
-		SDK::Transform_Set_localScale(bodyTransform, normalScale, nullptr);
 
-		auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
-		pos.Y -= m_offsetY;
-		SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
+	SDK::Transform_Set_localScale(bodyTransform, flippedScale, nullptr);
 
-		m_applied = false;
-	}
+	auto pos = m_baseBodyPos;
+	pos.Y += m_modelHeight;
+	SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -2,8 +2,8 @@
 
 using namespace PhasmoCheatV::Features::Misc;
 
-static const SDK::Vector3 flippedScale  = { 1.0f, -1.0f, 1.0f };
-static const SDK::Vector3 normalScale   = { 1.0f,  1.0f, 1.0f };
+static const SDK::Vector3 flippedScale = { 1.0f, -1.0f, 1.0f };
+static const SDK::Vector3 normalScale  = { 1.0f,  1.0f, 1.0f };
 
 GhostHandstand::GhostHandstand() : FeatureCore(LANG("GhostHandstand_Header"), TYPE_MISC)
 {
@@ -22,39 +22,35 @@ void GhostHandstand::OnMenuRender()
 
 void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 {
-	if (!ghostAI || !ghostAI->Fields.raycastPoint) return;
+	if (!ghostAI || !ghostAI->Fields.raycastPoint || !ghostAI->Fields.feetRaycastPoint) return;
 
 	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
 	if (!bodyTransform) return;
 
 	if (!IsActive())
 	{
-		if (m_basePosSet)
+		if (m_applied)
 		{
 			SDK::Transform_Set_localScale(bodyTransform, normalScale, nullptr);
-			SDK::Transform_Set_Position(bodyTransform, m_baseBodyPos, nullptr);
-			m_basePosSet = false;
+			m_applied = false;
 		}
 		return;
 	}
 
-	// Capture base position and model height on first active frame
-	if (!m_basePosSet)
+	// Calculate model height once on first frame (before scale flip)
+	if (!m_applied)
 	{
-		m_baseBodyPos = SDK::Transform_Get_Position(bodyTransform, nullptr);
-		if (ghostAI->Fields.feetRaycastPoint)
-		{
-			auto top = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr);
-			auto bottom = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr);
-			m_modelHeight = top.Y - bottom.Y;
-		}
-		if (m_modelHeight <= 0.0f) m_modelHeight = 1.8f;
-		m_basePosSet = true;
+		float topY  = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr).Y;
+		float feetY = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr).Y;
+		m_height = topY - feetY;
+		if (m_height <= 0.0f) m_height = 1.8f;
 	}
 
-	SDK::Transform_Set_localScale(bodyTransform, flippedScale, nullptr);
+	auto pos = SDK::Transform_Get_Position(bodyTransform, nullptr);
+	pos.Y += m_height;
 
-	auto pos = m_baseBodyPos;
-	pos.Y += m_modelHeight;
+	SDK::Transform_Set_localScale(bodyTransform, flippedScale, nullptr);
 	SDK::Transform_Set_Position(bodyTransform, pos, nullptr);
+
+	m_applied = true;
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -1,0 +1,37 @@
+#include "ghosthandstand.h"
+
+using namespace PhasmoCheatV::Features::Misc;
+
+// 180 degrees around X axis: (sin(pi/2), 0, 0, cos(pi/2)) = (1, 0, 0, 0)
+static const SDK::Quaternion handstandQuat = { 1.0f, 0.0f, 0.0f, 0.0f };
+static const SDK::Quaternion identityQuat   = { 0.0f, 0.0f, 0.0f, 1.0f };
+
+GhostHandstand::GhostHandstand() : FeatureCore(LANG("GhostHandstand_Header"), TYPE_MISC)
+{
+}
+
+void GhostHandstand::OnMenuRender()
+{
+	bool enabled = IsActive();
+	if (BCheckBox(LANG("GhostHandstandEnabled"), &enabled, "b_GhostHandstandEnabled"))
+	{
+		SET_CONFIG_VALUE(GetConfigManager(), "Enabled", bool, enabled);
+		if (enabled) OnActivate();
+		else OnDeactivate();
+	}
+}
+
+void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
+{
+	if (!ghostAI || !ghostAI->Fields.currentModel) return;
+
+	auto* animator = ghostAI->Fields.currentModel->Fields.anim;
+	if (!animator) return;
+
+	auto* modelTransform = SDK::Component_Get_Transform(
+		reinterpret_cast<SDK::Component*>(animator), nullptr);
+	if (!modelTransform) return;
+
+	SDK::Transform_Set_Rotation(modelTransform,
+		IsActive() ? handstandQuat : identityQuat, nullptr);
+}

--- a/main/features/feats/ghosthandstand/ghosthandstand.cpp
+++ b/main/features/feats/ghosthandstand/ghosthandstand.cpp
@@ -32,6 +32,34 @@ void GhostHandstand::GhostHandstandMain(SDK::GhostAI* ghostAI)
 		reinterpret_cast<SDK::Component*>(animator), nullptr);
 	if (!modelTransform) return;
 
-	SDK::Transform_Set_Rotation(modelTransform,
-		IsActive() ? handstandQuat : identityQuat, nullptr);
+	if (IsActive())
+	{
+		float ghostHeight = 0.0f;
+		if (ghostAI->Fields.raycastPoint && ghostAI->Fields.feetRaycastPoint)
+		{
+			auto top = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr);
+			auto bottom = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr);
+			ghostHeight = top.Y - bottom.Y;
+		}
+		if (ghostHeight <= 0.0f) ghostHeight = 1.8f;
+
+		SDK::Transform_Set_Rotation(modelTransform, handstandQuat, nullptr);
+
+		auto pos = SDK::Transform_Get_Position(modelTransform, nullptr);
+		pos.Y += ghostHeight;
+		SDK::Transform_Set_Position(modelTransform, pos, nullptr);
+
+		m_applied = true;
+		m_offsetY = ghostHeight;
+	}
+	else if (m_applied)
+	{
+		SDK::Transform_Set_Rotation(modelTransform, identityQuat, nullptr);
+
+		auto pos = SDK::Transform_Get_Position(modelTransform, nullptr);
+		pos.Y -= m_offsetY;
+		SDK::Transform_Set_Position(modelTransform, pos, nullptr);
+
+		m_applied = false;
+	}
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.h
+++ b/main/features/feats/ghosthandstand/ghosthandstand.h
@@ -9,14 +9,15 @@ namespace PhasmoCheatV::Features::Misc
 		explicit GhostHandstand();
 		~GhostHandstand() override = default;
 
-		void OnActivate() override {}
+		void OnActivate() override { m_basePosSet = false; }
 		void OnDeactivate() override {}
 		void OnRender() override {}
 		void OnMenuRender() override;
 
 		void GhostHandstandMain(SDK::GhostAI* ghostAI);
 	private:
-		bool  m_applied = false;
-		float m_offsetY = 0.0f;
+		SDK::Vector3 m_baseBodyPos = { 0, 0, 0 };
+		float m_modelHeight = 0.0f;
+		bool m_basePosSet = false;
 	};
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.h
+++ b/main/features/feats/ghosthandstand/ghosthandstand.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "../Includes.h"
+
+namespace PhasmoCheatV::Features::Misc
+{
+	class GhostHandstand final : public FeatureCore
+	{
+	public:
+		explicit GhostHandstand();
+		~GhostHandstand() override = default;
+
+		void OnActivate() override {}
+		void OnDeactivate() override {}
+		void OnRender() override {}
+		void OnMenuRender() override;
+
+		void GhostHandstandMain(SDK::GhostAI* ghostAI);
+	};
+}

--- a/main/features/feats/ghosthandstand/ghosthandstand.h
+++ b/main/features/feats/ghosthandstand/ghosthandstand.h
@@ -16,8 +16,7 @@ namespace PhasmoCheatV::Features::Misc
 
 		void GhostHandstandMain(SDK::GhostAI* ghostAI);
 	private:
-		SDK::Vector3 m_baseBodyPos = { 0, 0, 0 };
-		float m_modelHeight = 0.0f;
-		bool m_basePosSet = false;
+		bool  m_applied = false;
+		float m_height = 1.8f;
 	};
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.h
+++ b/main/features/feats/ghosthandstand/ghosthandstand.h
@@ -15,5 +15,8 @@ namespace PhasmoCheatV::Features::Misc
 		void OnMenuRender() override;
 
 		void GhostHandstandMain(SDK::GhostAI* ghostAI);
+	private:
+		bool  m_applied = false;
+		float m_offsetY = 0.0f;
 	};
 }

--- a/main/features/feats/ghosthandstand/ghosthandstand.h
+++ b/main/features/feats/ghosthandstand/ghosthandstand.h
@@ -9,7 +9,7 @@ namespace PhasmoCheatV::Features::Misc
 		explicit GhostHandstand();
 		~GhostHandstand() override = default;
 
-		void OnActivate() override { m_basePosSet = false; }
+		void OnActivate() override { m_applied = false; }
 		void OnDeactivate() override {}
 		void OnRender() override {}
 		void OnMenuRender() override;

--- a/main/features/feats/ghostspin/ghostspin.cpp
+++ b/main/features/feats/ghostspin/ghostspin.cpp
@@ -30,6 +30,18 @@ void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
 	if (!bodyTransform) return;
 
+	// Capture base position and model height on first frame
+	if (!m_basePosSet) {
+		m_baseBodyPos = SDK::Transform_Get_Position(bodyTransform, nullptr);
+		if (ghostAI->Fields.feetRaycastPoint) {
+			SDK::Vector3 top = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr);
+			SDK::Vector3 bottom = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr);
+			m_modelHeight = top.Y - bottom.Y;
+		}
+		if (m_modelHeight <= 0.0f) m_modelHeight = 1.8f;
+		m_basePosSet = true;
+	}
+
 	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
 	float dt = SDK::Time_Get_DeltaTime(nullptr);
 	m_spinAngle += speed * dt * 0.0174533f;
@@ -37,6 +49,12 @@ void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 
 	float halfAngle = m_spinAngle * 0.5f;
 	SDK::Quaternion yRot = { 0.0f, sinf(halfAngle), 0.0f, cosf(halfAngle) };
+
+	// Raise body up when inverted to prevent clipping into ground
+	SDK::Vector3 bodyPos = m_baseBodyPos;
+	float t = fabsf(sinf(m_spinAngle));
+	bodyPos.Y += m_modelHeight * t;
+	SDK::Transform_Set_Position(bodyTransform, bodyPos, nullptr);
 
 	SDK::Transform_Set_Rotation(bodyTransform, yRot, nullptr);
 }

--- a/main/features/feats/ghostspin/ghostspin.cpp
+++ b/main/features/feats/ghostspin/ghostspin.cpp
@@ -25,14 +25,10 @@ void GhostSpin::OnMenuRender()
 void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 {
 	if (!IsActive()) return;
-	if (!ghostAI || !ghostAI->Fields.currentModel) return;
+	if (!ghostAI || !ghostAI->Fields.raycastPoint) return;
 
-	auto* animator = ghostAI->Fields.currentModel->Fields.anim;
-	if (!animator) return;
-
-	auto* modelTransform = SDK::Component_Get_Transform(
-		reinterpret_cast<SDK::Component*>(animator), nullptr);
-	if (!modelTransform) return;
+	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
+	if (!bodyTransform) return;
 
 	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
 	float dt = SDK::Time_Get_DeltaTime(nullptr);
@@ -42,5 +38,5 @@ void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 	float halfAngle = m_spinAngle * 0.5f;
 	SDK::Quaternion yRot = { 0.0f, sinf(halfAngle), 0.0f, cosf(halfAngle) };
 
-	SDK::Transform_Set_Rotation(modelTransform, yRot, nullptr);
+	SDK::Transform_Set_Rotation(bodyTransform, yRot, nullptr);
 }

--- a/main/features/feats/ghostspin/ghostspin.cpp
+++ b/main/features/feats/ghostspin/ghostspin.cpp
@@ -30,18 +30,6 @@ void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 	auto* bodyTransform = SDK::Transform_Get_Parent(ghostAI->Fields.raycastPoint, nullptr);
 	if (!bodyTransform) return;
 
-	// Capture base position and model height on first frame
-	if (!m_basePosSet) {
-		m_baseBodyPos = SDK::Transform_Get_Position(bodyTransform, nullptr);
-		if (ghostAI->Fields.feetRaycastPoint) {
-			SDK::Vector3 top = SDK::Transform_Get_Position(ghostAI->Fields.raycastPoint, nullptr);
-			SDK::Vector3 bottom = SDK::Transform_Get_Position(ghostAI->Fields.feetRaycastPoint, nullptr);
-			m_modelHeight = top.Y - bottom.Y;
-		}
-		if (m_modelHeight <= 0.0f) m_modelHeight = 1.8f;
-		m_basePosSet = true;
-	}
-
 	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
 	float dt = SDK::Time_Get_DeltaTime(nullptr);
 	m_spinAngle += speed * dt * 0.0174533f;
@@ -49,12 +37,6 @@ void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
 
 	float halfAngle = m_spinAngle * 0.5f;
 	SDK::Quaternion yRot = { 0.0f, sinf(halfAngle), 0.0f, cosf(halfAngle) };
-
-	// Raise body up when inverted to prevent clipping into ground
-	SDK::Vector3 bodyPos = m_baseBodyPos;
-	float t = fabsf(sinf(m_spinAngle));
-	bodyPos.Y += m_modelHeight * t;
-	SDK::Transform_Set_Position(bodyTransform, bodyPos, nullptr);
 
 	SDK::Transform_Set_Rotation(bodyTransform, yRot, nullptr);
 }

--- a/main/features/feats/ghostspin/ghostspin.cpp
+++ b/main/features/feats/ghostspin/ghostspin.cpp
@@ -1,0 +1,46 @@
+#include "ghostspin.h"
+#include <cmath>
+
+using namespace PhasmoCheatV::Features::Misc;
+
+GhostSpin::GhostSpin() : FeatureCore(LANG("GhostSpin_Header"), TYPE_MISC)
+{
+	DECLARE_CONFIG(GetConfigManager(), "Speed", float, 360.0f);
+}
+
+void GhostSpin::OnMenuRender()
+{
+	bool enabled = IsActive();
+	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
+	if (BCheckBox(LANG("GhostSpinEnabled"), &enabled, "b_GhostSpinEnabled"))
+	{
+		SET_CONFIG_VALUE(GetConfigManager(), "Enabled", bool, enabled);
+		if (enabled) OnActivate();
+		else OnDeactivate();
+	}
+	if (ImGui::SliderFloat(LANG("GhostSpinSpeed"), &speed, 0.0f, 2000.0f, "%.0f deg/s"))
+		SET_CONFIG_VALUE(GetConfigManager(), "Speed", float, speed);
+}
+
+void GhostSpin::GhostSpinMain(SDK::GhostAI* ghostAI)
+{
+	if (!IsActive()) return;
+	if (!ghostAI || !ghostAI->Fields.currentModel) return;
+
+	auto* animator = ghostAI->Fields.currentModel->Fields.anim;
+	if (!animator) return;
+
+	auto* modelTransform = SDK::Component_Get_Transform(
+		reinterpret_cast<SDK::Component*>(animator), nullptr);
+	if (!modelTransform) return;
+
+	float speed = CONFIG_FLOAT(GetConfigManager(), "Speed");
+	float dt = SDK::Time_Get_DeltaTime(nullptr);
+	m_spinAngle += speed * dt * 0.0174533f;
+	if (m_spinAngle > 6.2831853f) m_spinAngle -= 6.2831853f;
+
+	float halfAngle = m_spinAngle * 0.5f;
+	SDK::Quaternion yRot = { 0.0f, sinf(halfAngle), 0.0f, cosf(halfAngle) };
+
+	SDK::Transform_Set_Rotation(modelTransform, yRot, nullptr);
+}

--- a/main/features/feats/ghostspin/ghostspin.h
+++ b/main/features/feats/ghostspin/ghostspin.h
@@ -9,7 +9,7 @@ namespace PhasmoCheatV::Features::Misc
 		explicit GhostSpin();
 		~GhostSpin() override = default;
 
-		void OnActivate() override { m_basePosSet = false; }
+		void OnActivate() override {}
 		void OnDeactivate() override {}
 		void OnRender() override {}
 		void OnMenuRender() override;
@@ -17,8 +17,5 @@ namespace PhasmoCheatV::Features::Misc
 		void GhostSpinMain(SDK::GhostAI* ghostAI);
 	private:
 		float m_spinAngle = 0.0f;
-		SDK::Vector3 m_baseBodyPos = { 0, 0, 0 };
-		float m_modelHeight = 0.0f;
-		bool m_basePosSet = false;
 	};
 }

--- a/main/features/feats/ghostspin/ghostspin.h
+++ b/main/features/feats/ghostspin/ghostspin.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../Includes.h"
+
+namespace PhasmoCheatV::Features::Misc
+{
+	class GhostSpin final : public FeatureCore
+	{
+	public:
+		explicit GhostSpin();
+		~GhostSpin() override = default;
+
+		void OnActivate() override {}
+		void OnDeactivate() override {}
+		void OnRender() override {}
+		void OnMenuRender() override;
+
+		void GhostSpinMain(SDK::GhostAI* ghostAI);
+	private:
+		float m_spinAngle = 0.0f;
+	};
+}

--- a/main/features/feats/ghostspin/ghostspin.h
+++ b/main/features/feats/ghostspin/ghostspin.h
@@ -9,7 +9,7 @@ namespace PhasmoCheatV::Features::Misc
 		explicit GhostSpin();
 		~GhostSpin() override = default;
 
-		void OnActivate() override {}
+		void OnActivate() override { m_basePosSet = false; }
 		void OnDeactivate() override {}
 		void OnRender() override {}
 		void OnMenuRender() override;
@@ -17,5 +17,8 @@ namespace PhasmoCheatV::Features::Misc
 		void GhostSpinMain(SDK::GhostAI* ghostAI);
 	private:
 		float m_spinAngle = 0.0f;
+		SDK::Vector3 m_baseBodyPos = { 0, 0, 0 };
+		float m_modelHeight = 0.0f;
+		bool m_basePosSet = false;
 	};
 }

--- a/main/features/feature.cpp
+++ b/main/features/feature.cpp
@@ -100,6 +100,7 @@ FeatureHandler::FeatureHandler() : CurrentType(TYPE_NONE)
     ADD_FEATURE(this, Teleport);
 
     // Misc
+    ADD_FEATURE(this, GhostSpin);
     ADD_FEATURE(this, AntiKick);
     ADD_FEATURE(this, ExitVanOne);
     ADD_FEATURE(this, VanButtonModifier);

--- a/main/features/feature.cpp
+++ b/main/features/feature.cpp
@@ -101,6 +101,7 @@ FeatureHandler::FeatureHandler() : CurrentType(TYPE_NONE)
 
     // Misc
     ADD_FEATURE(this, GhostSpin);
+    ADD_FEATURE(this, GhostHandstand);
     ADD_FEATURE(this, AntiKick);
     ADD_FEATURE(this, ExitVanOne);
     ADD_FEATURE(this, VanButtonModifier);

--- a/main/features/features_includes.h
+++ b/main/features/features_includes.h
@@ -25,6 +25,7 @@
 #include "feats/infstamina/infinitystamina.h"
 #include "feats/custspeed/customspeed.h"
 #include "feats/ghostspin/ghostspin.h"
+#include "feats/ghosthandstand/ghosthandstand.h"
 #include "feats/teleport/teleport.h"
 #include "feats/exitvanone/exitvanone.h"
 #include "feats/antikick/antikick.h"

--- a/main/features/features_includes.h
+++ b/main/features/features_includes.h
@@ -24,6 +24,7 @@
 #include "feats/noclip/noclip.h"
 #include "feats/infstamina/infinitystamina.h"
 #include "feats/custspeed/customspeed.h"
+#include "feats/ghostspin/ghostspin.h"
 #include "feats/teleport/teleport.h"
 #include "feats/exitvanone/exitvanone.h"
 #include "feats/antikick/antikick.h"

--- a/main/hooks/GhostAI_Update.cpp
+++ b/main/hooks/GhostAI_Update.cpp
@@ -13,6 +13,7 @@ void Hooks::hkGhostAI_Update(SDK::GhostAI* ghostAI, SDK::MethodInfo* methodInfo)
 
 	CALL_METHOD(Ghost, GhostModifier, GhostModifierMain);
 	CALL_METHOD(Ghost, GhostInteractor, GhostInteractorMain);
+	CALL_METHOD_IF_ACTIVE_ARGS(Misc, GhostSpin, GhostSpinMain, ghostAI);
 	CALL_METHOD(Players, Pickup, PickupMain);
 	CALL_METHOD(Map, GrabKeys, GrabKeysMain);
 	CALL_METHOD(Map, MapModifier, MapModifierMain);

--- a/main/hooks/GhostAI_Update.cpp
+++ b/main/hooks/GhostAI_Update.cpp
@@ -14,6 +14,7 @@ void Hooks::hkGhostAI_Update(SDK::GhostAI* ghostAI, SDK::MethodInfo* methodInfo)
 	CALL_METHOD(Ghost, GhostModifier, GhostModifierMain);
 	CALL_METHOD(Ghost, GhostInteractor, GhostInteractorMain);
 	CALL_METHOD_IF_ACTIVE_ARGS(Misc, GhostSpin, GhostSpinMain, ghostAI);
+	CALL_METHOD_ARGS(Misc, GhostHandstand, GhostHandstandMain, ghostAI);
 	CALL_METHOD(Players, Pickup, PickupMain);
 	CALL_METHOD(Map, GrabKeys, GrabKeysMain);
 	CALL_METHOD(Map, MapModifier, MapModifierMain);

--- a/main/sdk/Transform.h
+++ b/main/sdk/Transform.h
@@ -14,6 +14,7 @@ namespace SDK
     DEC_MET(Transform_Get_Up, Vector3(*)(Transform* transform, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "get_up", 0);
     DEC_MET(Transform_Get_Forward, Vector3(*)(Transform* transform, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "get_forward", 0);
     DEC_MET(Transform_Get_localScale, Vector3(*)(Transform* transform, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "get_localScale", 0);
+    DEC_MET(Transform_Set_localScale, void(*)(Transform* transform, Vector3 scale, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "set_localScale", 1);
 
     DEC_MET(Transform_Get_Rotation, Quaternion(*)(Transform* transform, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "get_rotation", 0);
     DEC_MET(Transform_Set_Rotation, void(*)(Transform* transform, Quaternion rotation, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Transform", "set_rotation", 1);


### PR DESCRIPTION
## Summary

Add two ghost trolling features: Ghost Spin (continuous Y-axis rotation) and Ghost Handstand (upside-down flip). Both can be enabled simultaneously without conflict.

## What it does

### Ghost Spin
- Continuous Y-axis rotation, 0 ~ 2000 deg/s (default 360)
- Driven by the `GhostAI.Update` hook

### Ghost Handstand
- Flips the ghost model upside-down via `Transform.localScale = (1, -1, 1)`
- Auto-calculates model height and offsets position to prevent ground clipping
- Restores to normal when disabled

## Known Issue

The handstand position compensation uses the host's local ghost height calculation. On client (non-host) machines, the ghost may appear higher than on the host. This is because the position offset is applied locally and the Photon network sync may not perfectly match the compensated transform between host and clients.

## How it works

### Ghost Spin
- Uses `Transform_Get_Parent(raycastPoint)` to get the ghost body root transform
- Sets Y-rotation quaternion each frame
- Avoids the Animator's transform (would be overwritten by the animation system)

### Ghost Handstand
- Uses `localScale` instead of rotation — this is an independent property, so Ghost Spin and Ghost Handstand don't conflict
- Height calculated once on the first active frame as `raycastPoint.Y - feetRaycastPoint.Y` with a 1.8m fallback
- Position offset applied each frame to keep the model above ground

### SDK addition
- Added `Transform_Set_localScale` declaration in `main/sdk/Transform.h`


https://github.com/user-attachments/assets/37378dc9-8b09-40e2-bdf9-71e7591850e0

https://github.com/user-attachments/assets/4484e04e-8faf-4f16-858f-13b172a4506b


